### PR TITLE
Allow dummy logger to produce messages with just printlns

### DIFF
--- a/src/main/kotlin/org/jetbrains/kotlin/konan/util/WithLogger.kt
+++ b/src/main/kotlin/org/jetbrains/kotlin/konan/util/WithLogger.kt
@@ -13,14 +13,12 @@ interface WithLogger {
     val logger: Logger
 }
 
-fun dummyLogger(message: String) {}
-
 object DummyLogger : Logger {
-    override fun log(message: String) = dummyLogger(message)
-    override fun error(message: String) = dummyLogger(message)
-    override fun warning(message: String) = dummyLogger(message)
+    override fun log(message: String) = println(message)
+    override fun error(message: String) = println("e: $message")
+    override fun warning(message: String) = println("w: $message")
     override fun fatal(message: String): Nothing {
-        dummyLogger(message)
+        println("e: $message")
         exitProcess(1)
     }
 }


### PR DESCRIPTION
Useful for applications working outside of the compiler infrastructure